### PR TITLE
Fixes install error with solr-cors

### DIFF
--- a/provisioning/roles/solr-cors/tasks/main.yml
+++ b/provisioning/roles/solr-cors/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Add CORS configuration to Solr
   become: yes
   blockinfile:
-    path: /opt/solr/example/solr-webapp/webapp/WEB-INF/web.xml
+    dest: /opt/solr/example/solr-webapp/webapp/WEB-INF/web.xml
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     # Multi-line matches were not working, so this more brittle match will be used.
     # The lines need to go right after the <web-app> tag.


### PR DESCRIPTION
When trying to build the Vagrant box after the update to Vagrant 2.1.2, I consistently get the following error:

```
TASK [solr-cors : Add CORS configuration to Solr] ******************************
fatal: [federated-search-demo]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: path"}
```

The following fixes the issue.