### PR TITLE
Root-198: solr config, autocomplete styles, + search terms field

### DIFF
--- a/conf/solr/drupal8/custom/solr-conf/4.x/schema.xml
+++ b/conf/solr/drupal8/custom/solr-conf/4.x/schema.xml
@@ -462,11 +462,6 @@
     <!-- This field is used to build the spellchecker index -->
     <field name="spell" type="textSpell" indexed="true" stored="true" multiValued="true"/>
 
-    <!-- Federated Search fields -->
-    <!-- See schema: https://www.drupal.org/docs/8/modules/search-api-federated-solr/federated-search-schema -->
-    <!-- Define any field used explicitly as a default or boost -->
-    <field name="tm_rendered_item" type="text" indexed="true" stored="true" multiValued="true" termVectors="true"/>
-
     <!-- copyField commands copy one field to another at the time a document
          is added to the index.  It's used either to index the same field differently,
          or to add multiple fields to the same field for easier/faster searching.  -->
@@ -600,7 +595,7 @@
   <uniqueKey>id</uniqueKey>
 
   <!-- field for the QueryParser to use when an explicit fieldname is absent -->
-  <defaultSearchField>tm_rendered_item</defaultSearchField>
+  <defaultSearchField>content</defaultSearchField>
 
   <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
   <solrQueryParser defaultOperator="OR"/>

--- a/conf/solr/drupal8/custom/solr-conf/4.x/schema_extra_fields.xml
+++ b/conf/solr/drupal8/custom/solr-conf/4.x/schema_extra_fields.xml
@@ -20,4 +20,8 @@
    <dynamicField name="tos_de_*" type="text_de" indexed="true" stored="true" multiValued="false" termVectors="true" omitNorms="true"/>
    <dynamicField name="tom_de_*" type="text_de" indexed="true" stored="true" multiValued="true" termVectors="true" omitNorms="true"/>
 -->
+    <!-- Federated Search fields -->
+    <!-- See schema: https://www.drupal.org/docs/8/modules/search-api-federated-solr/federated-search-schema -->
+    <!-- Define any field used explicitly as a default or boost -->
+    <field name="tm_rendered_item" type="text" indexed="true" stored="true" multiValued="true" termVectors="true"/>
 </fields>

--- a/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig.xml
+++ b/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig.xml
@@ -865,7 +865,7 @@
       <!-- Don't abort searches for the pinkPony request handler (set in solrcore.properties) -->
       <int name="timeAllowed">${solr.pinkPony.timeAllowed:-1}</int>
       <str name="q.alt">*:*</str>
-      <str name="qf">tm_rendered_item tem_full_text_title</str>
+      <str name="qf">tm_rendered_item tem_full_text_title tem_full_text_search_terms</str>
 
       <!-- By default, don't spell check -->
       <str name="spellcheck">false</str>

--- a/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig.xml
+++ b/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig.xml
@@ -865,7 +865,6 @@
       <!-- Don't abort searches for the pinkPony request handler (set in solrcore.properties) -->
       <int name="timeAllowed">${solr.pinkPony.timeAllowed:-1}</int>
       <str name="q.alt">*:*</str>
-      <str name="qf">tm_rendered_item tem_full_text_title tem_full_text_search_terms</str>
 
       <!-- By default, don't spell check -->
       <str name="spellcheck">false</str>

--- a/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig_extra.xml
+++ b/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig_extra.xml
@@ -1,80 +1,111 @@
-<!-- Spell Check
+<xi:include href="ThisFileDoesNotExist-ItsJustAHack.txt" xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:fallback>
 
-    The spell check component can return a list of alternative spelling
-    suggestions.
+    <!-- Spell Check
 
-    http://wiki.apache.org/solr/SpellCheckComponent
- -->
-<searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+     The spell check component can return a list of alternative spelling
+     suggestions.
 
-<str name="queryAnalyzerFieldType">textSpell</str>
-
-<!-- Multiple "Spell Checkers" can be declared and used by this
-     component
+     http://wiki.apache.org/solr/SpellCheckComponent
   -->
+    <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+      <str name="queryAnalyzerFieldType">textSpell</str>
+      <!-- Multiple "Spell Checkers" can be declared and used by this
+           component
+        -->
+      <!-- a spellchecker built from a field of the main index, and
+           written to disk
+        -->
+      <lst name="spellchecker">
+        <str name="name">default</str>
+        <str name="field">spell</str>
+        <str name="spellcheckIndexDir">spellchecker</str>
+        <str name="buildOnOptimize">true</str>
+        <!-- uncomment this to require terms to occur in 1% of the documents in order to be included in the dictionary
+          <float name="thresholdTokenFrequency">.01</float>
+        -->
+      </lst>
 
-<!-- a spellchecker built from a field of the main index, and
-     written to disk
-  -->
-<lst name="spellchecker">
-  <str name="name">default</str>
-  <str name="field">spell</str>
-  <str name="spellcheckIndexDir">spellchecker</str>
-  <str name="buildOnOptimize">true</str>
-  <!-- uncomment this to require terms to occur in 1% of the documents in order to be included in the dictionary
-    <float name="thresholdTokenFrequency">.01</float>
-  -->
-</lst>
+      <!--
+        Adding German spellhecker index to our Solr index
+        This also requires to enable the content in schema_extra_types.xml and schema_extra_fields.xml
+      -->
+      <!--
+      <lst name="spellchecker">
+        <str name="name">spellchecker_de</str>
+        <str name="field">spell_de</str>
+        <str name="spellcheckIndexDir">./spellchecker_de</str>
+        <str name="buildOnOptimize">true</str>
+      </lst>
+      -->
 
-<!--
-  Adding German spellhecker index to our Solr index
-  This also requires to enable the content in schema_extra_types.xml and schema_extra_fields.xml
--->
-<!--
-<lst name="spellchecker">
-  <str name="name">spellchecker_de</str>
-  <str name="field">spell_de</str>
-  <str name="spellcheckIndexDir">./spellchecker_de</str>
-  <str name="buildOnOptimize">true</str>
-</lst>
--->
+      <!-- a spellchecker that uses a different distance measure -->
+      <!--
+         <lst name="spellchecker">
+           <str name="name">jarowinkler</str>
+           <str name="field">spell</str>
+           <str name="distanceMeasure">
+             org.apache.lucene.search.spell.JaroWinklerDistance
+           </str>
+           <str name="spellcheckIndexDir">spellcheckerJaro</str>
+         </lst>
+       -->
 
-<!-- a spellchecker that uses a different distance measure -->
-<!--
-   <lst name="spellchecker">
-     <str name="name">jarowinkler</str>
-     <str name="field">spell</str>
-     <str name="distanceMeasure">
-       org.apache.lucene.search.spell.JaroWinklerDistance
-     </str>
-     <str name="spellcheckIndexDir">spellcheckerJaro</str>
-   </lst>
- -->
+      <!-- a spellchecker that use an alternate comparator
 
-<!-- a spellchecker that use an alternate comparator
+           comparatorClass be one of:
+            1. score (default)
+            2. freq (Frequency first, then score)
+            3. A fully qualified class name
+        -->
+      <!--
+         <lst name="spellchecker">
+           <str name="name">freq</str>
+           <str name="field">lowerfilt</str>
+           <str name="spellcheckIndexDir">spellcheckerFreq</str>
+           <str name="comparatorClass">freq</str>
+           <str name="buildOnCommit">true</str>
+        -->
 
-     comparatorClass be one of:
-      1. score (default)
-      2. freq (Frequency first, then score)
-      3. A fully qualified class name
-  -->
-<!--
-   <lst name="spellchecker">
-     <str name="name">freq</str>
-     <str name="field">lowerfilt</str>
-     <str name="spellcheckIndexDir">spellcheckerFreq</str>
-     <str name="comparatorClass">freq</str>
-     <str name="buildOnCommit">true</str>
-  -->
+      <!-- A spellchecker that reads the list of words from a file -->
+      <!--
+         <lst name="spellchecker">
+           <str name="classname">solr.FileBasedSpellChecker</str>
+           <str name="name">file</str>
+           <str name="sourceLocation">spellings.txt</str>
+           <str name="characterEncoding">UTF-8</str>
+           <str name="spellcheckIndexDir">spellcheckerFile</str>
+         </lst>
+        -->
+    </searchComponent>
 
-<!-- A spellchecker that reads the list of words from a file -->
-<!--
-   <lst name="spellchecker">
-     <str name="classname">solr.FileBasedSpellChecker</str>
-     <str name="name">file</str>
-     <str name="sourceLocation">spellings.txt</str>
-     <str name="characterEncoding">UTF-8</str>
-     <str name="spellcheckIndexDir">spellcheckerFile</str>
-   </lst>
-  -->
-</searchComponent>
+    <!-- trivia: the name pinkPony requestHandler was an agreement between the Search API and the
+    apachesolr maintainers. The decision was taken during the Drupalcon Munich codesprint.
+    -->
+    <requestHandler name="pinkPony" class="solr.SearchHandler" default="true">
+      <lst name="defaults">
+        <str name="defType">edismax</str>
+        <str name="echoParams">explicit</str>
+        <bool name="omitHeader">true</bool>
+        <float name="tie">0.01</float>
+        <!-- Don't abort searches for the pinkPony request handler (set in solrcore.properties) -->
+        <int name="timeAllowed">${solr.pinkPony.timeAllowed:-1}</int>
+        <str name="q.alt">*:*</str>
+        <str name="qf">tm_rendered_item tem_full_text_title tem_full_text_search_terms</str>
+
+        <!-- By default, don't spell check -->
+        <str name="spellcheck">false</str>
+        <!-- Defaults for the spell checker when used -->
+        <str name="spellcheck.onlyMorePopular">true</str>
+        <str name="spellcheck.extendedResults">false</str>
+        <!--  The number of suggestions to return -->
+        <str name="spellcheck.count">1</str>
+      </lst>
+      <arr name="last-components">
+        <str>spellcheck</str>
+      </arr>
+    </requestHandler>
+
+    <!-- Close out with the proper sections too -->
+  </xi:fallback>
+</xi:include>

--- a/config/sites/d8/core.entity_form_display.node.article.default.yml
+++ b/config/sites/d8/core.entity_form_display.node.article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.article.body
     - field.field.node.article.field_image
+    - field.field.node.article.field_search_terms
     - field.field.node.article.field_tags
     - image.style.thumbnail
     - node.type.article
@@ -31,18 +32,27 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_image:
     type: image_image
-    weight: 3
+    weight: 4
     region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
+  field_search_terms:
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
   field_tags:
     type: entity_reference_autocomplete_tags
     weight: 2
@@ -54,13 +64,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -68,21 +78,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 7
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 7
+    weight: 8
     region: content
     third_party_settings: {  }
   title:
@@ -95,7 +105,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/sites/d8/core.entity_form_display.node.recipe.default.yml
+++ b/config/sites/d8/core.entity_form_display.node.recipe.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.recipe.field_preparation_time
     - field.field.node.recipe.field_recipe_category
     - field.field.node.recipe.field_recipe_instruction
+    - field.field.node.recipe.field_search_terms
     - field.field.node.recipe.field_summary
     - field.field.node.recipe.field_tags
     - image.style.thumbnail
@@ -30,7 +31,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -57,7 +58,7 @@ content:
     type: options_select
     region: content
   field_image:
-    weight: 8
+    weight: 9
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -65,7 +66,7 @@ content:
     type: image_image
     region: content
   field_ingredients:
-    weight: 10
+    weight: 11
     settings:
       size: 60
       placeholder: ''
@@ -96,15 +97,24 @@ content:
     type: entity_reference_autocomplete_tags
     region: content
   field_recipe_instruction:
-    weight: 11
+    weight: 12
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
     region: content
+  field_search_terms:
+    weight: 7
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
   field_summary:
-    weight: 9
+    weight: 10
     settings:
       rows: 5
       placeholder: ''
@@ -112,7 +122,7 @@ content:
     type: text_textarea
     region: content
   field_tags:
-    weight: 7
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60
@@ -122,13 +132,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -136,21 +146,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 14
+    weight: 15
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 17
+    weight: 18
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 16
     region: content
     third_party_settings: {  }
   title:
@@ -163,7 +173,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/sites/d8/core.entity_view_display.node.article.default.yml
+++ b/config/sites/d8/core.entity_view_display.node.article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.article.body
     - field.field.node.article.field_image
+    - field.field.node.article.field_search_terms
     - field.field.node.article.field_tags
     - node.type.article
     - responsive_image.styles.3_2_image
@@ -21,20 +22,28 @@ mode: default
 content:
   body:
     type: text_default
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
     label: hidden
   field_image:
     type: responsive_image
-    weight: 1
+    weight: 2
     region: content
     settings:
       responsive_image_style: 3_2_image
       image_link: ''
     third_party_settings: {  }
     label: hidden
+  field_search_terms:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_tags:
     type: entity_reference_label
     weight: 0
@@ -44,7 +53,7 @@ content:
       link: true
     third_party_settings: {  }
   links:
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/d8/core.entity_view_display.node.article.full.yml
+++ b/config/sites/d8/core.entity_view_display.node.article.full.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.article.body
     - field.field.node.article.field_image
+    - field.field.node.article.field_search_terms
     - field.field.node.article.field_tags
     - node.type.article
     - responsive_image.styles.3_2_image
@@ -22,20 +23,28 @@ mode: full
 content:
   body:
     type: text_default
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
     label: hidden
   field_image:
     type: responsive_image
-    weight: 1
+    weight: 2
     region: content
     settings:
       responsive_image_style: 3_2_image
       image_link: ''
     third_party_settings: {  }
     label: hidden
+  field_search_terms:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
   field_tags:
     type: entity_reference_label
     weight: 0
@@ -45,7 +54,7 @@ content:
       link: true
     third_party_settings: {  }
   links:
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/d8/core.entity_view_display.node.recipe.default.yml
+++ b/config/sites/d8/core.entity_view_display.node.recipe.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.recipe.field_preparation_time
     - field.field.node.recipe.field_recipe_category
     - field.field.node.recipe.field_recipe_instruction
+    - field.field.node.recipe.field_search_terms
     - field.field.node.recipe.field_summary
     - field.field.node.recipe.field_tags
     - node.type.recipe
@@ -29,39 +30,6 @@ bundle: recipe
 mode: default
 content:
   field_cooking_time:
-    weight: 5
-    label: above
-    settings:
-      thousand_separator: ''
-      prefix_suffix: true
-    third_party_settings: {  }
-    type: number_integer
-    region: content
-  field_difficulty:
-    weight: 7
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: list_default
-    region: content
-  field_image:
-    weight: 3
-    label: hidden
-    settings:
-      responsive_image_style: 3_2_image
-      image_link: ''
-    third_party_settings: {  }
-    type: responsive_image
-    region: content
-  field_ingredients:
-    weight: 8
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_number_of_servings:
     weight: 6
     label: above
     settings:
@@ -70,8 +38,41 @@ content:
     third_party_settings: {  }
     type: number_integer
     region: content
-  field_preparation_time:
+  field_difficulty:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_image:
     weight: 4
+    label: hidden
+    settings:
+      responsive_image_style: 3_2_image
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    region: content
+  field_ingredients:
+    weight: 9
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_number_of_servings:
+    weight: 7
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+    region: content
+  field_preparation_time:
+    weight: 5
     label: above
     settings:
       thousand_separator: ''
@@ -88,11 +89,19 @@ content:
     type: entity_reference_label
     region: content
   field_recipe_instruction:
-    weight: 9
+    weight: 10
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_search_terms:
+    weight: 3
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_summary:
     weight: 0
@@ -110,7 +119,7 @@ content:
     type: entity_reference_label
     region: content
   links:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sites/d8/core.entity_view_display.node.recipe.full.yml
+++ b/config/sites/d8/core.entity_view_display.node.recipe.full.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.recipe.field_preparation_time
     - field.field.node.recipe.field_recipe_category
     - field.field.node.recipe.field_recipe_instruction
+    - field.field.node.recipe.field_search_terms
     - field.field.node.recipe.field_summary
     - field.field.node.recipe.field_tags
     - node.type.recipe
@@ -30,7 +31,7 @@ bundle: recipe
 mode: full
 content:
   field_cooking_time:
-    weight: 5
+    weight: 6
     label: inline
     settings:
       thousand_separator: ''
@@ -39,14 +40,14 @@ content:
     type: number_integer
     region: content
   field_difficulty:
-    weight: 7
+    weight: 8
     label: inline
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_image:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       responsive_image_style: 3_2_image
@@ -55,7 +56,7 @@ content:
     type: responsive_image
     region: content
   field_ingredients:
-    weight: 8
+    weight: 9
     label: above
     settings:
       link_to_entity: false
@@ -63,7 +64,7 @@ content:
     type: string
     region: content
   field_number_of_servings:
-    weight: 6
+    weight: 7
     label: inline
     settings:
       thousand_separator: ''
@@ -72,7 +73,7 @@ content:
     type: number_integer
     region: content
   field_preparation_time:
-    weight: 4
+    weight: 5
     label: inline
     settings:
       thousand_separator: ''
@@ -89,12 +90,20 @@ content:
     type: entity_reference_label
     region: content
   field_recipe_instruction:
-    weight: 9
+    weight: 10
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
+  field_search_terms:
+    type: entity_reference_label
+    weight: 3
+    region: content
+    label: inline
+    settings:
+      link: false
+    third_party_settings: {  }
   field_summary:
     weight: 0
     label: hidden

--- a/config/sites/d8/core.extension.yml
+++ b/config/sites/d8/core.extension.yml
@@ -43,6 +43,7 @@ module:
   search_api_federated_solr: 0
   search_api_field_map: 0
   search_api_solr: 0
+  serialization: 0
   shortcut: 0
   system: 0
   taxonomy: 0

--- a/config/sites/d8/core.extension.yml
+++ b/config/sites/d8/core.extension.yml
@@ -38,6 +38,7 @@ module:
   quickedit: 0
   rdf: 0
   responsive_image: 0
+  rest: 0
   search_api: 0
   search_api_federated_solr: 0
   search_api_field_map: 0

--- a/config/sites/d8/field.field.node.article.field_search_terms.yml
+++ b/config/sites/d8/field.field.node.article.field_search_terms.yml
@@ -1,0 +1,29 @@
+uuid: 165743f4-aadd-407b-9119-8fb5be0a4a06
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_search_terms
+    - node.type.article
+    - taxonomy.vocabulary.search_terms
+id: node.article.field_search_terms
+field_name: field_search_terms
+entity_type: node
+bundle: article
+label: 'Search terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      search_terms: search_terms
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sites/d8/field.field.node.recipe.field_search_terms.yml
+++ b/config/sites/d8/field.field.node.recipe.field_search_terms.yml
@@ -1,0 +1,29 @@
+uuid: ce1edc4f-cdf4-4ed0-8835-fd431031769c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_search_terms
+    - node.type.recipe
+    - taxonomy.vocabulary.search_terms
+id: node.recipe.field_search_terms
+field_name: field_search_terms
+entity_type: node
+bundle: recipe
+label: 'Search terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      search_terms: search_terms
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sites/d8/rest.settings.yml
+++ b/config/sites/d8/rest.settings.yml
@@ -1,0 +1,3 @@
+bc_entity_resource_permissions: false
+_core:
+  default_config_hash: Jg3_yqsTIZ51KOKp3OV2KDVVrlx3N3OCEfniEse09KE

--- a/config/sites/d8/search_api.index.federated_search_index.yml
+++ b/config/sites/d8/search_api.index.federated_search_index.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   module:
     - search_api_solr
+    - taxonomy
     - search_api
     - search_api_federated_solr
     - search_api_field_map
     - media
     - node
   config:
+    - field.storage.node.field_search_terms
     - search_api.server.local_solr
     - core.entity_view_mode.media.full
 id: federated_search_index
@@ -69,6 +71,18 @@ field_settings:
           article: Article
           page: Page
           recipe: Recipe
+  full_text_search_terms:
+    label: 'Search terms'
+    datasource_id: 'entity:node'
+    property_path: 'field_search_terms:entity:name'
+    type: solr_text_ngram
+    boost: !!float 5
+    dependencies:
+      config:
+        - field.storage.node.field_search_terms
+      module:
+        - taxonomy
+        - taxonomy
   full_text_title:
     label: 'Full Text Title'
     property_path: mapped_field

--- a/config/sites/d8/serialization.settings.yml
+++ b/config/sites/d8/serialization.settings.yml
@@ -1,0 +1,4 @@
+bc_primitives_as_strings: false
+bc_timestamp_normalizer_unix: false
+_core:
+  default_config_hash: 6A1rmsmNf4SJrwCEt_aZyO_kPYuFnIOPC2n5lJiIftA

--- a/web/d8-domain/docroot/modules/custom/federated_styles/css/search_theme_override.css
+++ b/web/d8-domain/docroot/modules/custom/federated_styles/css/search_theme_override.css
@@ -131,7 +131,9 @@ aside.l-25-75--1 {
       outline-width: 0;
       color: #002a5b;
       background-color: #e5e5e5;
-      border-bottom: 2px solid #002a5b; }
+      border-bottom: 2px solid #002a5b;
+      text-decoration: none;
+    }
   .search-results__label {
     color: #555;
     font-size: .8em; }

--- a/web/d8-domain/docroot/modules/custom/federated_styles/css/search_theme_override.css
+++ b/web/d8-domain/docroot/modules/custom/federated_styles/css/search_theme_override.css
@@ -85,6 +85,27 @@ aside.l-25-75--1 {
       fill: #222 !important; }
 
 /**
+* Autocomplete styles
+*/
+.search-form__autocomplete-container .react-autosuggest__input {
+  padding: .35em !important;
+  min-width: auto !important;
+  margin: 0 !important;
+}
+
+.search-form__autocomplete-container .react-autosuggest__input:focus {
+  border-width: 1px;
+}
+
+.search-form__autocomplete-container  .react-autosuggest__suggestions-container.react-autosuggest__suggestions-container--open {
+  top: 45px;
+}
+
+.search-form__autocomplete-container .search-form__submit {
+  padding: .35em .6em;
+}
+
+/**
  * Applied Filters
  */
 .applied-filters__filter {

--- a/web/d8/docroot/modules/custom/federated_styles/css/search_theme_override.css
+++ b/web/d8/docroot/modules/custom/federated_styles/css/search_theme_override.css
@@ -131,7 +131,9 @@ aside.l-25-75--1 {
       outline-width: 0;
       color: #002a5b;
       background-color: #e5e5e5;
-      border-bottom: 2px solid #002a5b; }
+      border-bottom: 2px solid #002a5b;
+      text-decoration: none;
+    }
   .search-results__label {
     color: #555;
     font-size: .8em; }

--- a/web/d8/docroot/modules/custom/federated_styles/css/search_theme_override.css
+++ b/web/d8/docroot/modules/custom/federated_styles/css/search_theme_override.css
@@ -70,7 +70,7 @@ aside.l-25-75--1 {
     outline: 0; }
 
 .search-form__submit {
-  // background-color: #ffcb05 !important;
+  /* background-color: #ffcb05 !important; */
   border-radius: 0 3px 3px 0 !important;
   border: 1px solid #e5e5e5 !important;
   border-left: 0 !important;
@@ -85,8 +85,29 @@ aside.l-25-75--1 {
       fill: #222 !important; }
 
 /**
- * Applied Filters
+ * Autocomplete styles
  */
+.search-form__autocomplete-container .react-autosuggest__input {
+  padding: .35em !important;
+  min-width: auto !important;
+  margin: 0 !important;
+}
+
+.search-form__autocomplete-container .react-autosuggest__input:focus {
+  border-width: 1px;
+}
+
+.search-form__autocomplete-container  .react-autosuggest__suggestions-container.react-autosuggest__suggestions-container--open {
+  top: 45px;
+}
+
+.search-form__autocomplete-container .search-form__submit {
+  padding: .35em .6em;
+}
+
+  /**
+   * Applied Filters
+   */
 .applied-filters__filter {
   border-bottom: solid 2px #ffcb05;
   font-size: .8em;


### PR DESCRIPTION
## Description

This PR update the demo site with some style updates for autocomplete content, a search terms term ref field on recipes, articles, and by backing out of the solr config updates in the original config files (solrconfig.xml, schema.xml) and making them in their respective *_extra.xml files to more closely match the necessary production experience. 

## Testing instructions

Test as part of https://github.com/palantirnet/search_api_federated_solr/pull/77